### PR TITLE
ci: Update pom version during release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     name: Sonar Scan & Quality Gate
     runs-on: ubuntu-latest
     needs: tests
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm install --no-save semantic-release \
+          npm install --ignore-scripts --no-save semantic-release \
             @semantic-release/git \
             @semantic-release/exec \
             @semantic-release/github \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   Release:
     runs-on: ubuntu-latest
@@ -34,8 +31,37 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: 'Release'
+      - name: Build & test
+        run: mvn -B -ntp verify
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn clean verify
-          npm install semantic-release -D
+          npm install --no-save semantic-release \
+            @semantic-release/git \
+            @semantic-release/exec \
+            @semantic-release/github \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator
+            
           npx semantic-release
+
+      - name: Sonar scan (Release)
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST: ${{ vars.SONAR_HOST }}
+          SONAR_ORG: ${{ vars.SONAR_ORG }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          echo "Running Sonar for release version: $VERSION"
+
+          mvn -B -ntp sonar:sonar \
+            -Dsonar.token=${{ env.SONAR_TOKEN }} \
+            -Dsonar.host.url=${{ env.SONAR_HOST }} \
+            -Dsonar.organization=${{ env.SONAR_ORG }} \
+            -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }} \
+            -Dsonar.projectVersion=${VERSION} \
+            -Dsonar.qualitygate.wait=true

--- a/.releaserc
+++ b/.releaserc
@@ -2,11 +2,41 @@
   "branches": [
     { "name": "main" },
     { "name": "beta", "prerelease": true },
-    { "name": "alpha", "prerelease": true },
+    { "name": "alpha", "prerelease": true }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "docs", "release": false },
+          { "type": "test", "release": false },
+          { "type": "chore", "release": false },
+          { "type": "build", "release": false },
+          { "type": "ci", "release": false }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "mvn versions:set -DnewVersion=${nextRelease.version} -DgenerateBackupPoms=false"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["pom.xml", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
     [
       "@semantic-release/github",
       {
@@ -14,6 +44,6 @@
           { "path": "target/thank-you-matcher-service-*.jar" }
         ]
       }
-    ],
+    ]
   ]
 }


### PR DESCRIPTION
Update the release workflow to update the version in the pom and commit it back to the branch. Additionally split the Sonar runs so that the ci workflow doesn't run Sonar on pushes to protected branches.
