### PR TITLE
fix(ci): use RELEASE_TOKEN for semantic-release to bypass main branch rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: 'Setup Java'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -43,7 +44,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           npm install --ignore-scripts --no-save semantic-release \
             @semantic-release/git \


### PR DESCRIPTION
## Summary
- Switches the release workflow from `GITHUB_TOKEN` to `RELEASE_TOKEN` (a fine-grained PAT) for both the checkout step and the semantic-release step
- `GITHUB_TOKEN` cannot be selected as a bypass actor in GitHub repository rulesets, so semantic-release's direct push to `main` was being rejected
- The PAT owner must be added as a bypass actor on the `main` branch ruleset in Settings → Rules

## Prerequisites before merging
- [x] Create a fine-grained PAT with `Contents: Read and write` and `Pull requests: Read and write` permissions scoped to this repo
- [x] Store it as a repo secret named `RELEASE_TOKEN`
- [x] Add the PAT owner as a bypass actor on the `main` branch ruleset

## Test plan
- [ ] Merge this PR to `beta`
- [ ] Verify the next `beta` release pushes successfully (already works via option 3 branch rule relaxation)
- [ ] Verify a `main` release pushes successfully once the prerequisites above are in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)